### PR TITLE
Bugfix: Importproblemen in modulaire structuur

### DIFF
--- a/pages/battery.py
+++ b/pages/battery.py
@@ -4,6 +4,11 @@ Battery page module for the Zonnepanelen_check application.
 This module contains the battery analysis page functionality.
 """
 import streamlit as st
+import sys
+import pathlib
+
+# Voeg de root directory toe aan het pad voor juiste imports
+sys.path.append(str(pathlib.Path(__file__).parent.parent))
 from battery_module import BatteryCalculator
 import visualization as viz
 from components.data_display import show_storage_results

--- a/pages/boiler.py
+++ b/pages/boiler.py
@@ -4,6 +4,11 @@ Boiler page module for the Zonnepanelen_check application.
 This module contains the water boiler analysis page functionality.
 """
 import streamlit as st
+import sys
+import pathlib
+
+# Voeg de root directory toe aan het pad voor juiste imports
+sys.path.append(str(pathlib.Path(__file__).parent.parent))
 from boiler_module import BoilerCalculator
 import visualization as viz
 from components.data_display import show_storage_results

--- a/pages/data_upload.py
+++ b/pages/data_upload.py
@@ -7,6 +7,10 @@ import streamlit as st
 import os
 import tempfile
 import pathlib
+import sys
+
+# Voeg de root directory toe aan het pad voor juiste imports
+sys.path.append(str(pathlib.Path(__file__).parent.parent))
 from components.data_display import show_data_metrics, show_energy_chart
 import visualization as viz
 
@@ -123,5 +127,9 @@ Date/Time,Energy Produced (Wh),Energy Consumed (Wh),Exported to Grid (Wh),Import
         # Show production & consumption chart
         st.subheader("Productie & Verbruik (Dagelijks)")
         if data_processor.daily_data is not None:
-            fig = viz.plot_energy_production_consumption(data_processor.data, period='daily')
-            st.plotly_chart(fig, use_container_width=True)
+            # Gebruik nu de show_energy_chart component voor betere herbruikbaarheid
+            show_energy_chart(data_processor.daily_data, period='daily')
+            
+            # Alternatieve methode met directe aanroep van viz module
+            # fig = viz.plot_energy_production_consumption(data_processor.data, period='daily')
+            # st.plotly_chart(fig, use_container_width=True)

--- a/pages/visualization.py
+++ b/pages/visualization.py
@@ -6,6 +6,11 @@ This module contains the visualization and comparison page functionality.
 import streamlit as st
 import pandas as pd
 import plotly.graph_objects as go
+import sys
+import pathlib
+
+# Voeg de root directory toe aan het pad voor juiste imports
+sys.path.append(str(pathlib.Path(__file__).parent.parent))
 import visualization as viz
 
 


### PR DESCRIPTION
## Bugfix voor importproblemen in modulaire structuur

Na de refactoring naar modulaire structuur treden er importproblemen op in verschillende pagina-modules. Hierdoor worden in sommige pagina's (zoals de Data Upload pagina) geen visualisaties meer getoond.

### Het probleem 
Python kan modules vanuit submappen niet zomaar importeren als de import verwijst naar bestanden in de hoofddirectory.

Bijvoorbeeld:
- pages/data_upload.py probeert `import visualization as viz` uit te voeren
- Dit werkt niet omdat Python eerst in de pages/ directory zoekt en niet in de root directory

### Oplossing:
1. `sys.path.append()` toegevoegd aan elke pagina-module om de hoofddirectory aan het Python pad toe te voegen
2. Gecorrigeerde imports die nu correct verwijzen naar modules
3. Extra verbetering: in data_upload.py nu ook de show_energy_chart component gebruiken voor betere herbruikbaarheid

### Geteste pagina's:
- data_upload.py - Productie & Verbruik visualisatie werkt nu correct
- visualization.py
- boiler.py
- battery.py

Dit zorgt ervoor dat alle visualisaties en functionaliteit nu correct werken in de modulaire structuur.