### PR TITLE
Fix error on Boiler page under 'Boiler Energy Usage and Gas Savings'

### DIFF
--- a/visualization/boiler_plots.py
+++ b/visualization/boiler_plots.py
@@ -73,33 +73,27 @@ def plot_boiler_energy_usage(boiler_results: Dict[str, Any]) -> go.Figure:
         yaxis="y2"
     ))
     
-    # Customize layout with simplified configuration
-    layout_config = {
-        'title': 'Boiler Energy Usage and Gas Savings',
-        'xaxis_title': 'Time',
-        'yaxis_title': 'Energy (kWh)',
-        'yaxis2': {
-            'title': 'Gas Saved (m³)',
-            'overlaying': 'y',
-            'side': 'right'
-        },
-        'template': 'plotly_white',
-        'legend': {
-            'orientation': 'h',
-            'yanchor': 'bottom',
-            'y': 1.02,
-            'xanchor': 'right',
-            'x': 1
-        }
-    }
-    
-    # Update layout with a try-except to handle potential configuration errors
-    try:
-        fig.update_layout(**layout_config)
-    except Exception as e:
-        print(f"Error updating layout: {e}")
-        # Fallback to minimal configuration if detailed config fails
-        fig.update_layout(title='Boiler Energy Usage and Gas Savings')
+    # Update layout
+    fig.update_layout(
+        title='Boiler Energy Usage and Gas Savings',
+        xaxis_title='Time',
+        yaxis_title='Energy (kWh)',
+        yaxis2=dict(
+            title='Gas Saved (m³)',
+            titlefont=dict(color='rgba(219, 64, 82, 1)'),
+            tickfont=dict(color='rgba(219, 64, 82, 1)'),
+            overlaying='y',
+            side='right'
+        ),
+        template='plotly_white',
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="right",
+            x=1
+        )
+    )
     
     return fig
 


### PR DESCRIPTION
## Beschrijving
Deze PR lost het probleem op dat is gemeld in issue #26: "Error op pagina 'Warmwaterboiler' onder 'Boiler Energiegebruik en Gasbesparing'".

## Probleem
Het probleem werd veroorzaakt door een fout in de implementatie van de `plot_boiler_energy_usage` functie in `visualization/boiler_plots.py`. De functie probeerde om layout configuratie via een dictionary toe te passen met behulp van `**kwargs`, maar dit veroorzaakte een fout bij het updaten van de yaxis2 instellingen.

## Oplossing
- Verwijderd de complexe constructie met een layout_config dictionary en try-except blok
- Direct de layout parameters doorgegeven aan de update_layout functie
- De yaxis2 parameter correct geformatteerd als een volledige dict met alle benodigde eigenschappen

## Gerelateerde Issues
Fixes #26